### PR TITLE
Use HTTPS for theme on bitbucket

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "name": "portlandlabs/addon_concrete5_theme",
         "version": "1.0.0",
         "source": {
-          "url": "git@bitbucket.org:portlandlabs/addon_concrete5_theme.git",
+          "url": "https://bitbucket.org/portlandlabs/addon_concrete5_theme.git",
           "type": "git",
           "reference": "master"
         }


### PR DESCRIPTION
I'm having issues installing the concrete5 theme using `git@bitbucket.org:...`

@KorvinSzanto So you see any issue if we switch to `https://bitbucket.org/...` ?