### PR TITLE
Add dotenv support so that we can include environment variables easily

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "concrete5/core": "dev-develop",
     "concrete5/community_translation": "@stable",
     "composer/installers": "dev-master",
-    "portlandlabs/addon_concrete5_theme": "^1.0"
+    "portlandlabs/addon_concrete5_theme": "^1.0",
+    "vlucas/phpdotenv": "^2.4"
   },
   "extra": {
     "installer-paths": {

--- a/public/application/bootstrap/autoload.php
+++ b/public/application/bootstrap/autoload.php
@@ -7,3 +7,10 @@ require_once dirname(__DIR__, 3) . "/vendor/autoload.php";
 # Add the vendor directory to the include path
 ini_set('include_path', dirname(__DIR__, 3) . "/vendor" . PATH_SEPARATOR . get_include_path());
 
+# Include the environment variables
+try {
+    $dotenv = new Dotenv\Dotenv(dirname(__DIR__, 3));
+    $dotenv->load();
+} catch (\Dotenv\Exception\InvalidPathException $e) {
+    // .env file doesn't exist.
+}

--- a/public/application/bootstrap/autoload.php
+++ b/public/application/bootstrap/autoload.php
@@ -9,7 +9,12 @@ ini_set('include_path', dirname(__DIR__, 3) . "/vendor" . PATH_SEPARATOR . get_i
 
 # Include the environment variables
 try {
+    // Include the env
     $dotenv = new Dotenv\Dotenv(dirname(__DIR__, 3));
+    $dotenv->load();
+
+    // Include the deploy number
+    $dotenv = new Dotenv\Dotenv(dirname(__DIR__, 3), '.deploy');
     $dotenv->load();
 } catch (\Dotenv\Exception\InvalidPathException $e) {
     // .env file doesn't exist.


### PR DESCRIPTION
this makes it so that you can add a `/.env` file and define variables in it that are accessible through `getenv()`