### PR TITLE
Add timing and commit to the footer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,11 @@
   "license": "MIT",
   "minimum-stability": "dev",
   "prefer-stable": true,
+  "autoload": {
+    "psr-4": {
+      "Concrete5\\Translate\\": "src"
+    }
+  },
   "require": {
     "illuminate/container": "5.2.*",
     "concrete5/core": "dev-develop",

--- a/public/application/bootstrap/app.php
+++ b/public/application/bootstrap/app.php
@@ -63,3 +63,12 @@
  *
  * ----------------------------------------------------------------------------
  */
+
+$class = \Concrete\Core\Http\ServerInterface::class;
+if ($app->resolved($class) && $server = $app->make($class)) {
+    $server->addMiddleware(new \Concrete5\Translate\Http\TimingMiddleware(), 100);
+} else {
+    $app->resolving($class, function(\Concrete\Core\Http\ServerInterface $server) {
+        $server->addMiddleware(new \Concrete5\Translate\Http\TimingMiddleware(), 100);
+    });
+}

--- a/public/application/elements/footer_navigation.php
+++ b/public/application/elements/footer_navigation.php
@@ -1,0 +1,174 @@
+<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+
+<footer>
+    <div class="lines">
+        <div class="container">
+            <div class="row">
+                <div clas="span12">
+                    <img src="/packages/concrete5_theme/themes/concrete5/images/footer_trees.png"/>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="built-with">
+        <div class="container">
+            <div class="row">
+                <div class="col-sm-4">
+                    <span class="built-with-the-best">Built with the Best:</span>
+                </div>
+                <div class="col-sm-2 text-center">
+                    <a href="https://jquery.com/" target="_blank">
+                        <img alt="concrete5 uses jQuery for all frontend functionality!"
+                             src="/packages/concrete5_theme/themes/concrete5/images/logos/jquery.png" />
+                    </a>
+                </div>
+                <div class="col-sm-2 text-center">
+                    <a href="http://symfony.com/" target="_blank">
+                        <img alt="Symfony lends us its router, class loader, eventing, and more!"
+                             src="/packages/concrete5_theme/themes/concrete5/images/logos/symfony.png" />
+                    </a>
+                </div>
+                <div class="col-sm-2 text-center">
+                    <a href="http://www.doctrine-project.org/" target="_blank">
+                        <img alt="concrete5 makes heavy use of doctrines database abstraction (DBAL) and its ORM!"
+                             src="/packages/concrete5_theme/themes/concrete5/images/logos/doctrine.png" />
+                    </a>
+                </div>
+                <div class="col-sm-2 text-center">
+                    <a href="http://laravel.com/" target="_blank">
+                        <img alt="Laravel gives us Config, Application Container, Filesystem, and more!"
+                             src="/packages/concrete5_theme/themes/concrete5/images/logos/laravel.png" />
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <? /*
+        <div class="menu">
+            <div class="container">
+                <div class="row">
+                    <div class="span1">
+                        <?php
+                        $a = new GlobalArea('Footer Instant Setup');
+                        $a->display();
+                        ?>
+                    </div>
+                    <div class="span1">
+                        <?php
+                        $a = new GlobalArea('Footer Addons');
+                        $a->display();
+                        ?>
+                    </div>
+                    <div class="span1">
+                        <?php
+                        $a = new GlobalArea('Footer Community');
+                        $a->display();
+                        ?>
+                    </div>
+                    <div class="span1">
+                        <?php
+                        $a = new GlobalArea('Footer Documentation');
+                        $a->display();
+                        ?>
+                    </div>
+                    <div class="span1">
+                        <?php
+                        $a = new GlobalArea('Footer Company');
+                        $a->display();
+                        ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+        */ ?>
+
+    <div class="menu">
+        <div class="container">
+            <div class="row">
+                <div class="col-sm-2 col-sm-offset-1">
+                    <p><a title="About" href="//www.concrete5.org/about"><strong>About</strong></a></p>
+                    <p><a title="Features" href="//www.concrete5.org/about/feature-index">Features</a></p>
+                    <p><a title="Case Studies" href="//www.concrete5.org/about/case_studies">Case Studies</a></p>
+                    <p><a title="Showcase" href="//www.concrete5.org/about/showcase">Showcase</a></p>
+                    <p><a title="Testimonials" href="//www.concrete5.org/about/testimonials">Testimonials</a></p>
+                    <p><a title="Blog" href="//www.concrete5.org/about/blog">Blog</a></p>
+                </div>
+                <div class="col-sm-2">
+                    <p><a title="Download &amp; Extend" href="//www.concrete5.org/marketplace/addons"><strong>Download &amp; Extend</strong></a></p>
+                    <p><a title="Themes" href="//www.concrete5.org/marketplace/themes">Themes</a></p>
+                    <p><a title="Install Add-ons" href="//www.concrete5.org/marketplace/how_to_install_add_ons_and_themes_">Install Add-ons</a></p>
+                    <p><a title="Hosting" href="//www.concrete5.org/download/hosting">Hosting</a></p>
+                    <p><a title="Enterprise" href="//www.concrete5.org/solutions">Enterprise</a></p>
+                    <p><a title="Download" href="//www.concrete5.org/download">Download</a></p>
+                </div>
+                <div class="col-sm-2">
+                    <p><a title="Community" href="//www.concrete5.org/community"><strong>Community</strong></a></p>
+                    <p><a title="Forums" href="//www.concrete5.org/community/forums">Forums</a></p>
+                    <p><a title="Developers" href="//www.concrete5.org/developers">Get Involved</a></p>
+                    <p><a title="Jobs" href="//www.concrete5.org/community/jobs">Job Board</a></p>
+                    <p><a title="International" href="//www.concrete5.org/community/international">International</a></p>
+                    <p><a title="Marketplace News" href="//www.concrete5.org/about/marketplace-news">Marketplace News</a></p>
+                    <p><a title="Security" href="//www.concrete5.org/developers/security">Security Disclosure</a></p>
+                </div>
+                <div class="col-sm-2">
+                    <p><a title="Getting Started" href="//documentation.concrete5.org/"><strong>Getting Started</strong></a></p>
+                    <p><a title="Try Now" href="//www.concrete5.org/trial">Try Now</a></p>
+                    <p><a title="Documentation" href="//documentation.concrete5.org/">Documentation</a></p>
+                    <p><a title="Installation" href="//documentation.concrete5.org/developers/installation/installation">Installation</a></p>
+                    <p><a title="Tutorials" href="//documentation.concrete5.org/tutorials">Tutorials</a></p>
+                    <p><a title="Training &amp; Certification" href="//www.concrete5.org/community/training1">Training &amp; Certification</a></p>
+                </div>
+                <div class="col-sm-2">
+                    <p><strong>Company</strong></p>
+                    <p><a title="Privacy Policy" href="//www.concrete5.org/help/legal/concrete5_org_privacy_policy">Privacy Policy</a></p>
+                    <p><a title="Terms of Use" href="//www.concrete5.org/help/legal/terms">Terms of Use</a></p>
+                    <p><a title="DMCA Takedown Policy" href="//www.concrete5.org/help/legal/dmca-takedown-policy">DMCA Take Down</a></p>
+                    <p><a title="Refund Policy" href="//www.concrete5.org/help/legal/refund-policy">Refund Policy</a></p>
+                    <p><a title="eNewsletters" href="//www.concrete5.org/community/enewsletters">eNewsletter</a></p>
+                    <p><a title="Swag" href="//www.concrete5.org/marketplace/swag">Swag</a></p>
+                    <p><a title="Contact Us" href="//www.concrete5.org/help/legal/contact_us">Contact Us</a></p>
+                </div>
+            </div>
+            <div class="row social" style="background-color: transparent;">
+                <div class="social-icons col-sm-offset-1">
+                    <aside style="text-align:left">
+                        <a href="https://twitter.com/concrete5" title="concrete5 on Twitter">
+                            <i class="fa fa-twitter"></i>
+                        </a>
+                        <a href="https://www.facebook.com/concrete5" title="concrete5 on Facebook">
+                            <i class="fa fa-facebook"></i>
+                        </a>
+                        <a href="https://www.youtube.com/channel/UCywmkk3TWHLcYyKafNDFCUA" title="concrete5 on Youtube">
+                            <i class="fa fa-youtube"></i>
+                        </a>
+                        <a href="https://www.github.com/concrete5" title="concrete5 on Github">
+                            <i class="fa fa-github-alt"></i>
+                        </a>
+                    </aside>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="social">
+        <div class="container">
+            <div class="row">
+                <div class="col-sm-6 text-left" id="built-with-left">
+                    <a href="http://www.portlandlabs.com/" target="_blank" title="PORTLAND LABS">
+                        <img src="/packages/concrete5_theme/themes/concrete5/images/logos/portlandlabs.png"  alt="Portland Labs"/>
+                    </a>
+                        <span>
+                            <span>Copyright <?= date('Y') ?> </span>
+                            <a style="color:#666" href="http://www.portlandlabs.com/" target="_blank">Portland Labs</a>
+                            <span>&nbsp; &middot; &nbsp; All Rights Reserved</span>
+                        </span>
+                </div>
+                <div class="col-sm-6 social-icons">
+                    <div class='pull-right' style="color:#666">
+                        <span>Rev. <strong><?= substr(getenv('COMMIT') ?: 'DEV', 0, 6) ?></strong> rendered in <strong>{{ RENDER_TOTAL }}</strong></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/src/Http/TimingMiddleware.php
+++ b/src/Http/TimingMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Concrete5\Translate\Http;
+
+use Concrete\Core\Http\Middleware\DelegateInterface;
+use Concrete\Core\Http\Middleware\MiddlewareInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class TimingMiddleware implements MiddlewareInterface
+{
+
+    /**
+     * Process the request and return a response
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param DelegateInterface $frame
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function process(Request $request, DelegateInterface $frame)
+    {
+        $start = microtime(true);
+        $response = $frame->next($request);
+        $end = microtime(true);
+
+        $body = $response->getContent();
+        $body = str_replace('{{ RENDER_TOTAL }}', $this->getTimeString($start, $end), $body);
+        return $response->setContent($body);
+    }
+
+    /**
+     * Get the timing string
+     *
+     * @param $start
+     * @param $end
+     * @return string
+     */
+    private function getTimeString($start, $end)
+    {
+        // Rounded to two decimal places
+        $ms = ceil(($end - $start) * 100000) / 100;
+        return "{$ms}ms";
+    }
+}


### PR DESCRIPTION
This overrides the footer element from the theme replacing the uptime monitoring statement with the current commit hash and a middleware that reports how long rendering took.